### PR TITLE
Delete README.mdown from generated projects

### DIFF
--- a/tasks/generate.rake
+++ b/tasks/generate.rake
@@ -6,8 +6,8 @@ task :generate do
   # Archive the current HEAD to 'dir'
   system "git archive HEAD | (cd #{ENV['dir']} && tar -xvf -)"
   
-  # Remove this rake task from the newly generated project
-  system "cd #{ENV['dir']}; rm #{File.join("tasks", "generate.rake")}"
+  # Remove this rake task and the README from the newly generated project
+  system "cd #{ENV['dir']}; rm #{File.join("tasks", "generate.rake")} README.mdown"
 
   puts "\n *** A new project has been generated at: #{(ENV['dir'])} ***"
 end


### PR DESCRIPTION
Hi,

I thought it would make sense to remove the README from generated projects. Maybe instead you could have a boilerplate README that would replace sinatra-bootstrap's one on a generate.
